### PR TITLE
implement preference highlighting after settings search

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -165,6 +165,48 @@ object PreferenceKeys {
 
     const val enableDoh = "enable_doh"
 
+    const val disableBatteryOptimization = "pref_disable_battery_optimization"
+
+    const val clearDatabase = "pref_clear_database"
+
+    const val clearCookies = "pref_clear_cookies"
+
+    const val refreshLibraryCovers = "pref_refresh_library_covers"
+
+    const val refreshLibraryTracking = "pref_refresh_library_tracking"
+
+    const val createBackup = "pref_create_backup"
+
+    const val restoreBackup = "pref_restore_backup"
+
+    const val manageNotifications = "pref_manage_notifications"
+
+    const val libraryColumns = "pref_library_columns"
+
+    const val actionEditCategories = "pref_action_edit_categories"
+
+    const val parentalControlsInfo = "pref_parental_controls_info"
+
+    const val aboutVersion = "pref_about_version"
+
+    const val aboutBuildTime = "pref_about_build_time"
+
+    const val aboutCheckForUpdates = "pref_about_check_for_updates"
+
+    const val aboutWhatsNew = "pref_about_whats_new"
+
+    const val aboutNotices = "pref_about_notices"
+
+    const val aboutWebsite = "pref_about_website"
+
+    const val aboutDiscord = "pref_about_discord"
+
+    const val aboutGitHub = "pref_about_github"
+
+    const val aboutLabelExtensions = "pref_about_label_extensions"
+
+    const val aboutLicenses = "pref_about_licenses"
+
     fun trackUsername(syncId: Int) = "pref_mangasync_username_$syncId"
 
     fun trackPassword(syncId: Int) = "pref_mangasync_password_$syncId"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseActivity.kt
@@ -10,6 +10,8 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.preference.PreferenceValues as Values
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.ui.security.SecureActivityDelegate
+import eu.kanade.tachiyomi.ui.setting.settingssearch.SettingsSearchHelper
+import eu.kanade.tachiyomi.util.lang.launchNow
 import eu.kanade.tachiyomi.util.system.LocaleHelper
 import uy.kohesive.injekt.injectLazy
 
@@ -76,6 +78,8 @@ abstract class BaseActivity<VB : ViewBinding> : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         secureActivityDelegate.onCreate()
+
+        launchNow { SettingsSearchHelper.initPreferenceSearchResultCollection(this@BaseActivity) }
     }
 
     override fun onResume() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/AboutController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/AboutController.kt
@@ -10,6 +10,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.mikepenz.aboutlibraries.LibsBuilder
 import eu.kanade.tachiyomi.BuildConfig
 import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.preference.PreferenceKeys as Keys
 import eu.kanade.tachiyomi.data.updater.UpdateChecker
 import eu.kanade.tachiyomi.data.updater.UpdateResult
 import eu.kanade.tachiyomi.data.updater.UpdaterService
@@ -45,6 +46,7 @@ class AboutController : SettingsController() {
         titleRes = R.string.pref_category_about
 
         preference {
+            key = Keys.aboutVersion
             titleRes = R.string.version
             summary = if (BuildConfig.DEBUG) {
                 "Preview r${BuildConfig.COMMIT_COUNT} (${BuildConfig.COMMIT_SHA})"
@@ -55,17 +57,20 @@ class AboutController : SettingsController() {
             onClick { copyDebugInfo() }
         }
         preference {
+            key = Keys.aboutBuildTime
             titleRes = R.string.build_time
             summary = getFormattedBuildTime()
         }
         if (isUpdaterEnabled) {
             preference {
+                key = Keys.aboutCheckForUpdates
                 titleRes = R.string.check_for_updates
 
                 onClick { checkVersion() }
             }
         }
         preference {
+            key = Keys.aboutWhatsNew
             titleRes = R.string.whats_new
 
             onClick {
@@ -81,6 +86,7 @@ class AboutController : SettingsController() {
         }
         if (BuildConfig.DEBUG) {
             preference {
+                key = Keys.aboutNotices
                 titleRes = R.string.notices
 
                 onClick {
@@ -91,7 +97,10 @@ class AboutController : SettingsController() {
         }
 
         preferenceCategory {
+            titleRes = R.string.about_resources
+
             preference {
+                key = Keys.aboutWebsite
                 titleRes = R.string.website
                 val url = "https://tachiyomi.org"
                 summary = url
@@ -101,6 +110,7 @@ class AboutController : SettingsController() {
                 }
             }
             preference {
+                key = Keys.aboutDiscord
                 title = "Discord"
                 val url = "https://discord.gg/tachiyomi"
                 summary = url
@@ -110,6 +120,7 @@ class AboutController : SettingsController() {
                 }
             }
             preference {
+                key = Keys.aboutGitHub
                 title = "GitHub"
                 val url = "https://github.com/inorichi/tachiyomi"
                 summary = url
@@ -119,6 +130,7 @@ class AboutController : SettingsController() {
                 }
             }
             preference {
+                key = Keys.aboutLabelExtensions
                 titleRes = R.string.label_extensions
                 val url = "https://github.com/inorichi/tachiyomi-extensions"
                 summary = url
@@ -128,6 +140,7 @@ class AboutController : SettingsController() {
                 }
             }
             preference {
+                key = Keys.aboutLicenses
                 titleRes = R.string.licenses
 
                 onClick {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreController.kt
@@ -19,7 +19,6 @@ import eu.kanade.tachiyomi.ui.download.DownloadController
 import eu.kanade.tachiyomi.ui.setting.SettingsController
 import eu.kanade.tachiyomi.ui.setting.SettingsMainController
 import eu.kanade.tachiyomi.ui.setting.settingssearch.SettingsSearchController
-import eu.kanade.tachiyomi.ui.setting.settingssearch.SettingsSearchHelper
 import eu.kanade.tachiyomi.util.preference.add
 import eu.kanade.tachiyomi.util.preference.iconRes
 import eu.kanade.tachiyomi.util.preference.iconTint
@@ -49,7 +48,6 @@ class MoreController :
     private var downloadQueueSize: Int = 0
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) = screen.apply {
-        SettingsSearchHelper.initPreferenceSearchResultCollection(context, preferenceManager)
         titleRes = R.string.label_more
 
         val tintColor = context.getResourceColor(R.attr.colorAccent)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsAdvancedController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsAdvancedController.kt
@@ -33,7 +33,6 @@ import rx.schedulers.Schedulers
 import uy.kohesive.injekt.injectLazy
 
 class SettingsAdvancedController : SettingsController() {
-
     private val network: NetworkHelper by injectLazy()
 
     private val chapterCache: ChapterCache by injectLazy()
@@ -43,7 +42,6 @@ class SettingsAdvancedController : SettingsController() {
     @SuppressLint("BatteryLife")
     override fun setupPreferenceScreen(screen: PreferenceScreen) = screen.apply {
         titleRes = R.string.pref_category_advanced
-
         switchPreference {
             key = "acra.enable"
             titleRes = R.string.pref_enable_acra
@@ -53,6 +51,7 @@ class SettingsAdvancedController : SettingsController() {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             preference {
+                key = Keys.disableBatteryOptimization
                 titleRes = R.string.pref_disable_battery_optimization
                 summaryRes = R.string.pref_disable_battery_optimization_summary
 
@@ -86,6 +85,7 @@ class SettingsAdvancedController : SettingsController() {
                 onClick { clearChapterCache() }
             }
             preference {
+                key = Keys.clearDatabase
                 titleRes = R.string.pref_clear_database
                 summaryRes = R.string.pref_clear_database_summary
 
@@ -101,6 +101,7 @@ class SettingsAdvancedController : SettingsController() {
             titleRes = R.string.label_network
 
             preference {
+                key = Keys.clearCookies
                 titleRes = R.string.pref_clear_cookies
 
                 onClick {
@@ -120,11 +121,13 @@ class SettingsAdvancedController : SettingsController() {
             titleRes = R.string.label_library
 
             preference {
+                key = Keys.refreshLibraryCovers
                 titleRes = R.string.pref_refresh_library_covers
 
                 onClick { LibraryUpdateService.start(context, target = Target.COVERS) }
             }
             preference {
+                key = Keys.refreshLibraryTracking
                 titleRes = R.string.pref_refresh_library_tracking
                 summaryRes = R.string.pref_refresh_library_tracking_summary
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBackupController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBackupController.kt
@@ -53,6 +53,7 @@ class SettingsBackupController : SettingsController() {
         titleRes = R.string.backup
 
         preference {
+            key = Keys.createBackup
             titleRes = R.string.pref_create_backup
             summaryRes = R.string.pref_create_backup_summ
 
@@ -67,6 +68,7 @@ class SettingsBackupController : SettingsController() {
             }
         }
         preference {
+            key = Keys.restoreBackup
             titleRes = R.string.pref_restore_backup
             summaryRes = R.string.pref_restore_backup_summ
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsController.kt
@@ -1,6 +1,9 @@
 package eu.kanade.tachiyomi.ui.setting
 
+import android.animation.ArgbEvaluator
+import android.animation.ValueAnimator
 import android.content.Context
+import android.graphics.Color
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.ContextThemeWrapper
@@ -9,6 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.PreferenceController
+import androidx.preference.PreferenceGroup
 import androidx.preference.PreferenceScreen
 import com.bluelinelabs.conductor.ControllerChangeHandler
 import com.bluelinelabs.conductor.ControllerChangeType
@@ -26,6 +30,7 @@ import uy.kohesive.injekt.api.get
 
 abstract class SettingsController : PreferenceController() {
 
+    var preferenceKey: String? = null
     val preferences: PreferencesHelper = Injekt.get()
     val scope = CoroutineScope(Job() + Dispatchers.Main)
 
@@ -37,6 +42,24 @@ abstract class SettingsController : PreferenceController() {
             untilDestroySubscriptions = CompositeSubscription()
         }
         return super.onCreateView(inflater, container, savedInstanceState)
+    }
+
+    override fun onAttach(view: View) {
+        super.onAttach(view)
+
+        preferenceKey?.let { prefKey ->
+            val adapter = listView.adapter
+            scrollToPreference(prefKey)
+
+            listView.post {
+                if (adapter is PreferenceGroup.PreferencePositionCallback) {
+                    val pos = adapter.getPreferenceAdapterPosition(prefKey)
+                    listView.findViewHolderForAdapterPosition(pos)?.let {
+                        animatePreferenceHighlight(it.itemView)
+                    }
+                }
+            }
+        }
     }
 
     override fun onDestroyView(view: View) {
@@ -56,6 +79,17 @@ abstract class SettingsController : PreferenceController() {
         val tv = TypedValue()
         activity!!.theme.resolveAttribute(R.attr.preferenceTheme, tv, true)
         return ContextThemeWrapper(activity, tv.resourceId)
+    }
+
+    private fun animatePreferenceHighlight(view: View) {
+        val duration = 500L
+        val repeat = 2
+
+        val colorAnimation = ValueAnimator.ofObject(ArgbEvaluator(), Color.TRANSPARENT, Color.WHITE)
+        colorAnimation.duration = duration
+        colorAnimation.repeatCount = repeat
+        colorAnimation.addUpdateListener { animator -> view.setBackgroundColor(animator.animatedValue as Int) }
+        colorAnimation.reverse()
     }
 
     open fun getTitle(): String? {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
@@ -47,6 +47,7 @@ class SettingsGeneralController : SettingsController() {
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             preference {
+                key = Keys.manageNotifications
                 titleRes = R.string.pref_manage_notifications
                 onClick {
                     val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
@@ -50,6 +50,7 @@ class SettingsLibraryController : SettingsController() {
             titleRes = R.string.pref_category_display
 
             preference {
+                key = Keys.libraryColumns
                 titleRes = R.string.pref_library_columns
                 onClick {
                     LibraryColumnsDialog().showDialog(router)
@@ -83,6 +84,7 @@ class SettingsLibraryController : SettingsController() {
             titleRes = R.string.pref_category_library_categories
 
             preference {
+                key = Keys.actionEditCategories
                 titleRes = R.string.action_edit_categories
 
                 val catCount = dbCategories.size

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsMainController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsMainController.kt
@@ -7,7 +7,6 @@ import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.base.controller.withFadeTransaction
 import eu.kanade.tachiyomi.ui.setting.settingssearch.SettingsSearchController
-import eu.kanade.tachiyomi.ui.setting.settingssearch.SettingsSearchHelper
 import eu.kanade.tachiyomi.util.preference.iconRes
 import eu.kanade.tachiyomi.util.preference.iconTint
 import eu.kanade.tachiyomi.util.preference.onClick
@@ -23,8 +22,6 @@ import reactivecircus.flowbinding.appcompat.queryTextEvents
 class SettingsMainController : SettingsController() {
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) = screen.apply {
-        SettingsSearchHelper.initPreferenceSearchResultCollection(context, preferenceManager)
-
         titleRes = R.string.label_settings
 
         val tintColor = context.getResourceColor(R.attr.colorAccent)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/settingssearch/SettingsSearchHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/settingssearch/SettingsSearchHelper.kt
@@ -94,12 +94,21 @@ object SettingsSearchHelper {
                 val summary = if (pref.summary != null) pref.summary.toString() else ""
                 val breadcrumbsStr = breadcrumbs + " > ${pref.title}"
 
-                prefSearchResultList.add(SettingsSearchResult(title, summary, breadcrumbsStr, ctrl))
+                prefSearchResultList.add(
+                    SettingsSearchResult(
+                        key = pref.key,
+                        title = title,
+                        summary = summary,
+                        breadcrumb = breadcrumbsStr,
+                        searchController = ctrl
+                    )
+                )
             }
         }
     }
 
     data class SettingsSearchResult(
+        val key: String?,
         val title: String,
         val summary: String,
         val breadcrumb: String,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/settingssearch/SettingsSearchHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/settingssearch/SettingsSearchHelper.kt
@@ -6,8 +6,6 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceGroup
 import androidx.preference.PreferenceManager
-import eu.kanade.tachiyomi.ui.browse.extension.ExtensionFilterController
-import eu.kanade.tachiyomi.ui.browse.source.SourceFilterController
 import eu.kanade.tachiyomi.ui.more.AboutController
 import eu.kanade.tachiyomi.ui.setting.SettingsAdvancedController
 import eu.kanade.tachiyomi.ui.setting.SettingsBackupController
@@ -41,8 +39,6 @@ object SettingsSearchHelper {
         SettingsReaderController::class,
         SettingsSecurityController::class,
         SettingsTrackingController::class,
-        ExtensionFilterController::class,
-        SourceFilterController::class,
         AboutController::class
     )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/settingssearch/SettingsSearchHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/settingssearch/SettingsSearchHelper.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.ui.setting.settingssearch
 
+import android.annotation.SuppressLint
 import android.content.Context
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
@@ -48,7 +49,10 @@ object SettingsSearchHelper {
     /**
      * Must be called to populate `prefSearchResultList`
      */
-    fun initPreferenceSearchResultCollection(context: Context, preferenceManager: PreferenceManager) {
+    @SuppressLint("RestrictedApi")
+    fun initPreferenceSearchResultCollection(context: Context) {
+        val preferenceManager = PreferenceManager(context)
+
         prefSearchResultList.clear()
 
         settingControllersList.forEach { kClass ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/settingssearch/SettingsSearchHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/settingssearch/SettingsSearchHolder.kt
@@ -17,9 +17,11 @@ class SettingsSearchHolder(view: View, val adapter: SettingsSearchAdapter) :
     init {
         title_wrapper.setOnClickListener {
             adapter.getItem(bindingAdapterPosition)?.let {
-                val ctrl = it.settingsSearchResult.searchController
-                // needs to be a new instance to avoid this error https://github.com/bluelinelabs/Conductor/issues/446
-                adapter.titleClickListener.onTitleClick(ctrl::class.createInstance())
+                val ctrl = it.settingsSearchResult.searchController::class.createInstance()
+                ctrl.preferenceKey = it.settingsSearchResult.key
+
+                // must pass a new Controller instance to avoid this error https://github.com/bluelinelabs/Conductor/issues/446
+                adapter.titleClickListener.onTitleClick(ctrl)
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -411,6 +411,7 @@
     <string name="licenses">Open source licenses</string>
     <string name="check_for_updates">Check for updates</string>
     <string name="updated_version">Updated to v%1$s</string>
+    <string name="about_resources">Resources</string>
 
     <!-- ACRA -->
     <string name="pref_enable_acra">Send crash reports</string>


### PR DESCRIPTION
demo: https://streamable.com/0odjjj

- [x] Ensure all `Preferences` have a `key` set or else the highlighting effect will have no effect on it.
  - [x] `pref_disable_battery_optimization`
  - [x] `pref_clear_database`
  - [x] `pref_clear_cookies`
  - [x] `pref_refresh_library_covers`
  - [x] `pref_refresh_library_tracking`
  - [x] `pref_create_backup`
  - [x] `pref_restore_backup`
  - [x] `pref_manage_notifications`
  - [x] `pref_library_columns`
  - [x] `action_edit_categories`
  - [x] all preferences in `AboutController`


- [x] remove `ExtensionFilterController` and `SourceFilterController` from `settingControllersList` in `SettingsSearchHelper`, since those are related to Extensions and not Settings






ref: https://github.com/inorichi/tachiyomi/pull/3683